### PR TITLE
Fix GitHub logo height: remove padding-top that was squishing 32x32 i…

### DIFF
--- a/site/public/styles/global.css
+++ b/site/public/styles/global.css
@@ -52,7 +52,6 @@ img { max-width: 100%; }
 
 .site-header .github-link img {
   display: block;
-  padding-top: 4px;
 }
 
 /* ── Main content container ────────────────────────────────── */


### PR DESCRIPTION
…mage to 32x28