### PR TITLE
SEO fixes round 2

### DIFF
--- a/site/src/content/posts/multiple-environments-on-same-service-fabric-cluster.md
+++ b/site/src/content/posts/multiple-environments-on-same-service-fabric-cluster.md
@@ -1,5 +1,5 @@
 ---
-title: "Multiple environments on the same Service Fabric cluster"
+title: "Multiple environments on Service Fabric"
 publishedOn: 2020-10-09
 updatedOn: 2020-10-18
 description: "How to deploy the same application type multiple times on the same Service Fabric cluster, to act like multiple environments"

--- a/site/src/content/posts/search-non-ascii-characters.md
+++ b/site/src/content/posts/search-non-ascii-characters.md
@@ -2,7 +2,7 @@
 title: "Search Non-ASCII characters"
 publishedOn: 2019-10-23
 updatedOn: 2019-10-24
-description: "How to search for non-ASCII characters in your code using regular expressions. Use the pattern [^\\x00-\\x7f] in VS Code with regex mode enabled to find any character outside the standard ASCII range."
+description: "How to find non-ASCII characters in your code using the regex pattern [^\\x00-\\x7f] in VS Code with regex mode enabled."
 ---
 
 I can't remember where I got this one, but here it is:

--- a/site/src/content/posts/slug-or-permalink.md
+++ b/site/src/content/posts/slug-or-permalink.md
@@ -2,7 +2,7 @@
 title: "Slug or Permalink"
 publishedOn: 2019-10-15
 updatedOn: 2019-10-16
-description: "What is a slug and how to create one from a blog post title. Turns out what most people call a permalink is actually a slug — the human-readable part of a URL. Includes a JavaScript slugify function."
+description: "What is a slug vs a permalink? A slug is the human-readable part of a URL. Includes a JavaScript slugify function to generate slugs from blog post titles."
 ---
 
 Turns out what I call permalink is actually called *Slug*, permalink is the full URL and slug is "the part of a URL that identifies a page in human-readable keywords" you can read more about on [Wikipedia's Clean URL / Slug article](https://en.wikipedia.org/wiki/Clean_URL#Slug) and [Wikipedia's Permalink article](https://en.wikipedia.org/wiki/Permalink).

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -9,7 +9,7 @@ interface Props {
 
 const { title, description, type = 'website', publishedOn, updatedOn } = Astro.props;
 const base = import.meta.env.BASE_URL;
-const canonicalUrl = Astro.url.href;
+const canonicalUrl = Astro.url.href.replace(/\.html$/, '');
 const siteName = "Luciano's blog";
 ---
 


### PR DESCRIPTION
Addresses the new alerts from the follow-up SEO audit.

## Changes

- **Canonical URL** — strip `.html` from canonical and `og:url` so they match the sitemap's clean URLs, resolving all duplicate content and non-canonical sitemap alerts
- **Long meta descriptions** — trimmed `search-non-ascii-characters` and `slug-or-permalink` to under 160 chars (they were overcorrected in the previous round)
- **Long title** — shortened `multiple-environments` post title further to fit under 60 chars total including the site name prefix

## Not addressed

- HSTS, CSP, Content-Type-Options — requires custom HTTP headers, not supported on GitHub Pages without a CDN
- External follow links — acceptable for a personal blog
- Orphan/duplicate `.html` URLs — will resolve once canonical fix is live