### PR TITLE
feat: add dark mode toggle button

### DIFF
--- a/site/public/styles/global.css
+++ b/site/public/styles/global.css
@@ -11,6 +11,19 @@
   --max-width: 1024px;
 }
 
+/* ── Dark mode ─────────────────────────────────────────── */
+[data-theme="dark"] {
+  --color-primary: #7986cb;
+  --color-primary-dark: #5c6bc0;
+  --color-text: #e0e0e0;
+  --color-text-light: #aaa;
+  --color-border: #444;
+  --color-code-bg: #2d2d2d;
+  --color-code-text: #e0e0e0;
+  background: #1a1a1a;
+  color-scheme: dark;
+}
+
 /* ── Reset & base ──────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
 
@@ -25,6 +38,26 @@ html, body {
 a { color: inherit; }
 
 img { max-width: 100%; }
+
+/* ── Theme toggle button ──────────────────────────────────── */
+#theme-toggle {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 4px 8px;
+  line-height: 1;
+  color: #fff;
+}
+
+#theme-toggle:hover {
+  border-color: rgba(255,255,255,0.7);
+  background: rgba(255,255,255,0.1);
+}
+
+[data-theme="light"] .theme-icon-dark { display: none; }
+[data-theme="dark"]  .theme-icon-light { display: none; }
 
 /* ── Site header ───────────────────────────────────────────── */
 .site-header {

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -23,6 +23,13 @@ const siteName = "Luciano's blog";
     <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" type="image/x-icon" href={`${base}favicon.ico`} />
     <link rel="stylesheet" href={`${base}styles/global.css`} />
+    <script is:inline>
+      (() => {
+        const stored = localStorage.getItem('theme');
+        const dark = stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+      })();
+    </script>
     <script defer src="https://cloud.umami.is/script.js" data-website-id="5027eb92-ec33-4e41-a40c-a944a2dc66d7"></script>
 
     <!-- Open Graph -->
@@ -43,6 +50,10 @@ const siteName = "Luciano's blog";
     <header class="site-header">
       <nav>
         <a href={base}>Luciano's blog</a>
+        <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <span class="theme-icon-light">☀️</span>
+          <span class="theme-icon-dark">🌙</span>
+        </button>
         <a
           class="github-link"
           href="https://github.com/lgoncalv/blog.luciano.goncalves.dev"
@@ -59,6 +70,14 @@ const siteName = "Luciano's blog";
       <slot />
     </main>
 
+    <script>
+      document.getElementById('theme-toggle')?.addEventListener('click', () => {
+        const el = document.documentElement;
+        const next = el.dataset.theme === 'dark' ? 'light' : 'dark';
+        el.dataset.theme = next;
+        localStorage.setItem('theme', next);
+      });
+    </script>
     <script>
       import mermaid from 'mermaid';
 


### PR DESCRIPTION
- Add [data-theme='dark'] CSS custom property overrides in global.css
- Add theme toggle button with sun/moon emoji icons in header nav
- Inline script in <head> reads localStorage or prefers-color-scheme to avoid FOUC
- Click handler persists preference to localStorage